### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -62,6 +62,10 @@ export const baseOptions: BaseLayoutProps = {
           text: "Metis Sepolia Faucet",
           url: "https://faucet.metis.io/",
         },
+        {
+          text: "ethfaucet.com",
+          url: "https://ethfaucet.com?utm_source=metis_docs&utm_medium=docs",
+        },
       ],
     },
     { type: "main", text: "Status", url: "https://status.metis.io" },


### PR DESCRIPTION
Description
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with gas on Metis network for free, claimable once every 24 hours.

Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.